### PR TITLE
font-lock-builtin-face does not match the color-theme version from emacs-starter-kit

### DIFF
--- a/blackboard-theme.el
+++ b/blackboard-theme.el
@@ -29,7 +29,7 @@
  `(bold-italic ((t (:bold t))))
  `(border-glyph ((t (nil))))
  `(buffers-tab ((t (:background "#0C1021" :foreground "#F8F8F8"))))
- `(font-lock-builtin-face ((t (:foreground "#F8F8F8"))))
+ `(font-lock-builtin-face ((t (:foreground "#94bff3"))))
  `(font-lock-comment-face ((t (:italic t :foreground "#AEAEAE"))))
  `(font-lock-constant-face ((t (:foreground "#D8FA3C"))))
  `(font-lock-doc-string-face ((t (:foreground "DarkOrange"))))


### PR DESCRIPTION
I noticed when trying to switch to your version of the blackboard theme that the color for font-lock-builtin-face did not match the color-theme version I was using, which came from emacs-starter-kit.

This makes the values the same between the two versions.
